### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Lightninghawk mary.west@sparkfun.com
 maintainer=SparkFun Electronics sparkfun.com
 sentence=Library for the DRV2605L Haptic Motor Driver
 paragraph=This Library allows communication over I2C, select between 7 modes and 2 motor types.    
-category=Motor Drivers
+category=Device Control
 url=https://github.com/sparkfun/SparkFun_Haptic_Motor_Driver_Arduino_Library
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'Motor Drivers' in library SparkFun Haptic Motor Driver is not valid. Setting to 'Uncategorized'
```
on every compilation. `category` must be set to one of the values
listed in the Arduino Library specification:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format